### PR TITLE
fix: resolve all compiler warnings

### DIFF
--- a/src/lazy-list.mbti
+++ b/src/lazy-list.mbti
@@ -3,11 +3,11 @@ package "CAIMEOX/lazy-list"
 
 import(
   "CAIMEOX/lazy"
-  "moonbitlang/core/immut/list"
+  "moonbitlang/core/list"
 )
 
 // Values
-fn[X : Default] default() -> LazyList[X]
+fn[X] default() -> LazyList[X]
 
 fn[X : Add] infinite_stream(X, X) -> LazyList[X]
 
@@ -37,7 +37,7 @@ fn[T] LazyList::flatten(Self[Self[T]]) -> Self[T]
 fn[T, U] LazyList::fold_left(Self[T], (U, T) -> U, init~ : U) -> U
 fn[T, U] LazyList::fold_right(Self[T], (T, U) -> U, init~ : U) -> U
 fn[T] LazyList::from_array(Array[T]) -> Self[T]
-fn[T] LazyList::from_list(@list.T[T]) -> Self[T]
+fn[T] LazyList::from_list(@list.List[T]) -> Self[T]
 fn[T] LazyList::head(Self[T]) -> T
 fn[T] LazyList::index(Self[T], Int) -> T
 fn[T] LazyList::length(Self[T]) -> Int
@@ -50,7 +50,7 @@ fn[T] LazyList::take_while(Self[T], (T) -> Bool) -> Self[T]
 fn[T] LazyList::to_array(Self[T]) -> Array[T]
 fn[T] LazyList::unfold(Self[T], (Self[T]) -> (T, Self[T])?) -> Self[T]
 fn[T, W] LazyList::unzip(Self[(T, W)]) -> (Self[T], Self[W])
-fn[A, B, C] LazyList::zip_lazy_normal(Self[A], (A, B) -> C, @list.T[B]) -> @list.T[C]
+fn[A, B, C] LazyList::zip_lazy_normal(Self[A], (A, B) -> C, @list.List[B]) -> @list.List[C]
 fn[A, B, C] LazyList::zip_with(Self[A], Self[B], (A, B) -> C) -> Self[C]
 impl[T] Add for LazyList[T]
 impl[T : Eq] Eq for LazyList[T]

--- a/src/lazy-list.mbti
+++ b/src/lazy-list.mbti
@@ -1,102 +1,57 @@
-package CAIMEOX/lazy-list
+// Generated using `moon info`, DON'T EDIT IT
+package "CAIMEOX/lazy-list"
 
-alias @CAIMEOX/lazy as @lazy
-alias @moonbitlang/core/immut/list as @list
+import(
+  "CAIMEOX/lazy"
+  "moonbitlang/core/immut/list"
+)
 
 // Values
-fn concat[T](LazyList[T], LazyList[T]) -> LazyList[T]
+fn[X : Default] default() -> LazyList[X]
 
-fn default[X : Default]() -> LazyList[X]
-
-fn drop[T](LazyList[T], Int) -> LazyList[T]
-
-fn drop_while[T](LazyList[T], (T) -> Bool) -> LazyList[T]
-
-fn each[T](LazyList[T], (T) -> Unit) -> Unit
-
-fn eachi[T](LazyList[T], (Int, T) -> Unit) -> Unit
-
-fn filter[T](LazyList[T], (T) -> Bool) -> LazyList[T]
-
-fn flat_map[T, U](LazyList[T], (T) -> LazyList[U]) -> LazyList[U]
-
-fn flatten[T](LazyList[LazyList[T]]) -> LazyList[T]
-
-fn fold_left[T, U](LazyList[T], (U, T) -> U, init~ : U) -> U
-
-fn fold_right[T, U](LazyList[T], (T, U) -> U, init~ : U) -> U
-
-fn head[T](LazyList[T]) -> T
-
-fn index[T](LazyList[T], Int) -> T
-
-fn infinite_stream[X : Add](X, X) -> LazyList[X]
-
-fn length[T](LazyList[T]) -> Int
-
-fn map[T, U](LazyList[T], (T) -> U) -> LazyList[U]
+fn[X : Add] infinite_stream(X, X) -> LazyList[X]
 
 fn nats() -> LazyList[Int]
 
-fn repeat[T](T) -> LazyList[T]
+fn[T] repeat(T) -> LazyList[T]
 
-fn split_at[T](LazyList[T], Int) -> (LazyList[T], LazyList[T])
+fn[X : Add] sum(LazyList[X], init~ : X) -> X
 
-fn sum[X : Add](LazyList[X], init~ : X) -> X
+fn[T] zip_plus((T, T) -> T, LazyList[T], LazyList[T]) -> LazyList[T]
 
-fn tail[T](LazyList[T]) -> LazyList[T]
-
-fn tails[T](LazyList[T]) -> LazyList[LazyList[T]]
-
-fn take[T](LazyList[T], Int) -> LazyList[T]
-
-fn take_while[T](LazyList[T], (T) -> Bool) -> LazyList[T]
-
-fn to_array[T](LazyList[T]) -> Array[T]
-
-fn unfold[T](LazyList[T], (LazyList[T]) -> (T, LazyList[T])?) -> LazyList[T]
-
-fn unzip[T, W](LazyList[(T, W)]) -> (LazyList[T], LazyList[W])
-
-fn zip_lazy_normal[A, B, C](LazyList[A], (A, B) -> C, @list.T[B]) -> @list.T[C]
-
-fn zip_plus[T]((T, T) -> T, LazyList[T], LazyList[T]) -> LazyList[T]
-
-fn zip_with[A, B, C](LazyList[A], LazyList[B], (A, B) -> C) -> LazyList[C]
+// Errors
 
 // Types and methods
 pub(all) enum LazyList[T] {
   Nil
   Cons(T, @lazy.Lazy[LazyList[T]])
 }
-impl LazyList {
-  concat[T](Self[T], Self[T]) -> Self[T]
-  drop[T](Self[T], Int) -> Self[T]
-  drop_while[T](Self[T], (T) -> Bool) -> Self[T]
-  each[T](Self[T], (T) -> Unit) -> Unit
-  eachi[T](Self[T], (Int, T) -> Unit) -> Unit
-  filter[T](Self[T], (T) -> Bool) -> Self[T]
-  flat_map[T, U](Self[T], (T) -> Self[U]) -> Self[U]
-  flatten[T](Self[Self[T]]) -> Self[T]
-  fold_left[T, U](Self[T], (U, T) -> U, init~ : U) -> U
-  fold_right[T, U](Self[T], (T, U) -> U, init~ : U) -> U
-  from_array[T](Array[T]) -> Self[T]
-  from_list[T](@list.T[T]) -> Self[T]
-  head[T](Self[T]) -> T
-  index[T](Self[T], Int) -> T
-  length[T](Self[T]) -> Int
-  map[T, U](Self[T], (T) -> U) -> Self[U]
-  split_at[T](Self[T], Int) -> (Self[T], Self[T])
-  tail[T](Self[T]) -> Self[T]
-  tails[T](Self[T]) -> Self[Self[T]]
-  take[T](Self[T], Int) -> Self[T]
-  take_while[T](Self[T], (T) -> Bool) -> Self[T]
-  to_array[T](Self[T]) -> Array[T]
-  unfold[T](Self[T], (Self[T]) -> (T, Self[T])?) -> Self[T]
-  unzip[T, W](Self[(T, W)]) -> (Self[T], Self[W])
-  zip_lazy_normal[A, B, C](Self[A], (A, B) -> C, @list.T[B]) -> @list.T[C]
-  zip_with[A, B, C](Self[A], Self[B], (A, B) -> C) -> Self[C]
-}
+fn[T] LazyList::concat(Self[T], Self[T]) -> Self[T]
+fn[T] LazyList::drop(Self[T], Int) -> Self[T]
+fn[T] LazyList::drop_while(Self[T], (T) -> Bool) -> Self[T]
+fn[T] LazyList::each(Self[T], (T) -> Unit) -> Unit
+fn[T] LazyList::eachi(Self[T], (Int, T) -> Unit) -> Unit
+fn[T] LazyList::filter(Self[T], (T) -> Bool) -> Self[T]
+fn[T, U] LazyList::flat_map(Self[T], (T) -> Self[U]) -> Self[U]
+fn[T] LazyList::flatten(Self[Self[T]]) -> Self[T]
+fn[T, U] LazyList::fold_left(Self[T], (U, T) -> U, init~ : U) -> U
+fn[T, U] LazyList::fold_right(Self[T], (T, U) -> U, init~ : U) -> U
+fn[T] LazyList::from_array(Array[T]) -> Self[T]
+fn[T] LazyList::from_list(@list.T[T]) -> Self[T]
+fn[T] LazyList::head(Self[T]) -> T
+fn[T] LazyList::index(Self[T], Int) -> T
+fn[T] LazyList::length(Self[T]) -> Int
+fn[T, U] LazyList::map(Self[T], (T) -> U) -> Self[U]
+fn[T] LazyList::split_at(Self[T], Int) -> (Self[T], Self[T])
+fn[T] LazyList::tail(Self[T]) -> Self[T]
+fn[T] LazyList::tails(Self[T]) -> Self[Self[T]]
+fn[T] LazyList::take(Self[T], Int) -> Self[T]
+fn[T] LazyList::take_while(Self[T], (T) -> Bool) -> Self[T]
+fn[T] LazyList::to_array(Self[T]) -> Array[T]
+fn[T] LazyList::unfold(Self[T], (Self[T]) -> (T, Self[T])?) -> Self[T]
+fn[T, W] LazyList::unzip(Self[(T, W)]) -> (Self[T], Self[W])
+fn[A, B, C] LazyList::zip_lazy_normal(Self[A], (A, B) -> C, @list.T[B]) -> @list.T[C]
+fn[A, B, C] LazyList::zip_with(Self[A], Self[B], (A, B) -> C) -> Self[C]
 impl[T] Add for LazyList[T]
 impl[T : Eq] Eq for LazyList[T]
 impl[T : Show] Show for LazyList[T]

--- a/src/lazy_list.mbt
+++ b/src/lazy_list.mbt
@@ -1,10 +1,10 @@
 ///| A lazy list library providing efficient, on-demand evaluation of list operations.
 /// The library supports common list operations like map, filter, fold, etc., but
 /// evaluates them lazily, only computing elements when needed.
-typealias Lazy[T] = @lazy.Lazy[T]
+typealias @lazy.Lazy
 
 ///|
-typealias List[T] = @immut/list.T[T]
+typealias @immut/list.T as List
 
 ///|
 /// A lazy list type that can be either empty (Nil) or a head element with a lazily
@@ -16,13 +16,13 @@ pub(all) enum LazyList[T] {
 
 ///|
 /// Creates a default empty lazy list for types that implement Default.
-pub fn default[X : Default]() -> LazyList[X] {
+pub fn[X : Default] default() -> LazyList[X] {
   Nil
 }
 
 ///|
 /// Converts an immutable List to a LazyList.
-pub fn LazyList::from_list[T](ls : List[T]) -> LazyList[T] {
+pub fn[T] LazyList::from_list(ls : List[T]) -> LazyList[T] {
   loop ls, Nil {
     Nil, acc => acc
     Cons(x, xs), acc => continue xs, Cons(x, Lazy::from_value(acc))
@@ -31,7 +31,7 @@ pub fn LazyList::from_list[T](ls : List[T]) -> LazyList[T] {
 
 ///|
 /// Converts an Array to a LazyList in reverse order.
-pub fn LazyList::from_array[T](ar : Array[T]) -> LazyList[T] {
+pub fn[T] LazyList::from_array(ar : Array[T]) -> LazyList[T] {
   loop ar.length() - 1, Nil {
     -1, acc => acc
     n, acc => continue n - 1, Cons(ar[n], Lazy::from_value(acc))
@@ -59,7 +59,7 @@ pub impl[T : Eq] Eq for LazyList[T] with op_equal(self, other) {
 
 ///|
 /// Gets the element at a specific index in the lazy list.
-pub fn index[T](self : LazyList[T], i : Int) -> T {
+pub fn[T] index(self : LazyList[T], i : Int) -> T {
   match (self, i) {
     (Cons(x, _), 0) => x
     (Nil, _) => abort("index: out of bounds")
@@ -69,7 +69,7 @@ pub fn index[T](self : LazyList[T], i : Int) -> T {
 
 ///|
 /// Returns a lazy list of all final segments of the original list.
-pub fn tails[T](self : LazyList[T]) -> LazyList[LazyList[T]] {
+pub fn[T] tails(self : LazyList[T]) -> LazyList[LazyList[T]] {
   fn go(xs) {
     Cons(
       xs,
@@ -85,7 +85,7 @@ pub fn tails[T](self : LazyList[T]) -> LazyList[LazyList[T]] {
 
 ///|
 /// Concatenates two lazy lists together.
-pub fn concat[T](self : LazyList[T], other : LazyList[T]) -> LazyList[T] {
+pub fn[T] concat(self : LazyList[T], other : LazyList[T]) -> LazyList[T] {
   match self {
     Nil => other
     Cons(x, xs) =>
@@ -101,13 +101,13 @@ pub impl[T] Add for LazyList[T] with op_add(self, other) {
 
 ///|
 /// Creates an infinite lazy list repeating the same value.
-pub fn repeat[T](val : T) -> LazyList[T] {
+pub fn[T] repeat(val : T) -> LazyList[T] {
   Cons(val, @lazy.Lazy::from_thunk(fn() { repeat(val) }))
 }
 
 ///|
 /// Maps a function over a lazy list.
-pub fn map[T, U](self : LazyList[T], f : (T) -> U) -> LazyList[U] {
+pub fn[T, U] map(self : LazyList[T], f : (T) -> U) -> LazyList[U] {
   match self {
     Nil => Nil
     Cons(x, xs) =>
@@ -117,9 +117,9 @@ pub fn map[T, U](self : LazyList[T], f : (T) -> U) -> LazyList[U] {
 
 ///|
 /// Flat maps a function over a lazy list.
-pub fn flat_map[T, U](
+pub fn[T, U] flat_map(
   self : LazyList[T],
-  f : (T) -> LazyList[U]
+  f : (T) -> LazyList[U],
 ) -> LazyList[U] {
   match self {
     Nil => Nil
@@ -129,7 +129,7 @@ pub fn flat_map[T, U](
 
 ///|
 /// Flattens a lazy list of lazy lists into a single lazy list.
-pub fn flatten[T](self : LazyList[LazyList[T]]) -> LazyList[T] {
+pub fn[T] flatten(self : LazyList[LazyList[T]]) -> LazyList[T] {
   match self {
     Nil => Nil
     Cons(h, t) => h.concat(flatten(t.force()))
@@ -138,7 +138,7 @@ pub fn flatten[T](self : LazyList[LazyList[T]]) -> LazyList[T] {
 
 ///|
 /// Splits a lazy list at the given index.
-pub fn split_at[T](self : LazyList[T], i : Int) -> (LazyList[T], LazyList[T]) {
+pub fn[T] split_at(self : LazyList[T], i : Int) -> (LazyList[T], LazyList[T]) {
   if i <= 0 {
     (Nil, self)
   } else {
@@ -159,7 +159,7 @@ pub fn split_at[T](self : LazyList[T], i : Int) -> (LazyList[T], LazyList[T]) {
 
 ///|
 /// Left fold over a lazy list.
-pub fn fold_left[T, U](self : LazyList[T], f : (U, T) -> U, init~ : U) -> U {
+pub fn[T, U] fold_left(self : LazyList[T], f : (U, T) -> U, init~ : U) -> U {
   match self {
     Nil => init
     Cons(x, xs) => fold_left(xs.force(), f, init=f(init, x))
@@ -168,7 +168,7 @@ pub fn fold_left[T, U](self : LazyList[T], f : (U, T) -> U, init~ : U) -> U {
 
 ///|
 /// Right fold over a lazy list.
-pub fn fold_right[T, U](self : LazyList[T], f : (T, U) -> U, init~ : U) -> U {
+pub fn[T, U] fold_right(self : LazyList[T], f : (T, U) -> U, init~ : U) -> U {
   match self {
     Nil => init
     Cons(y, ys) => f(y, ys.force().fold_right(f, init~))
@@ -177,7 +177,7 @@ pub fn fold_right[T, U](self : LazyList[T], f : (T, U) -> U, init~ : U) -> U {
 
 ///|
 /// Gets the first element of a lazy list.
-pub fn head[T](self : LazyList[T]) -> T {
+pub fn[T] head(self : LazyList[T]) -> T {
   match self {
     Cons(x, _) => x
     Nil => abort("head: empty list")
@@ -186,7 +186,7 @@ pub fn head[T](self : LazyList[T]) -> T {
 
 ///|
 /// Gets the tail of a lazy list.
-pub fn tail[T](self : LazyList[T]) -> LazyList[T] {
+pub fn[T] tail(self : LazyList[T]) -> LazyList[T] {
   match self {
     Cons(_, xs) => xs.force()
     Nil => abort("tail: empty list")
@@ -195,7 +195,7 @@ pub fn tail[T](self : LazyList[T]) -> LazyList[T] {
 
 ///|
 /// Computes the length of a lazy list.
-pub fn length[T](self : LazyList[T]) -> Int {
+pub fn[T] length(self : LazyList[T]) -> Int {
   loop self, 0 {
     Nil, l => l
     Cons(_, xs), l => continue xs.force(), l + 1
@@ -204,7 +204,7 @@ pub fn length[T](self : LazyList[T]) -> Int {
 
 ///|
 /// Applies a function to each element of a lazy list for side effects.
-pub fn each[T](self : LazyList[T], f : (T) -> Unit) -> Unit {
+pub fn[T] each(self : LazyList[T], f : (T) -> Unit) -> Unit {
   loop self {
     Nil => ()
     Cons(h, t) => {
@@ -216,7 +216,7 @@ pub fn each[T](self : LazyList[T], f : (T) -> Unit) -> Unit {
 
 ///|
 /// Applies a function to each element with its index for side effects.
-pub fn eachi[T](self : LazyList[T], f : (Int, T) -> Unit) -> Unit {
+pub fn[T] eachi(self : LazyList[T], f : (Int, T) -> Unit) -> Unit {
   loop self, 0 {
     Nil, _ => ()
     Cons(x, xs), i => {
@@ -228,16 +228,16 @@ pub fn eachi[T](self : LazyList[T], f : (Int, T) -> Unit) -> Unit {
 
 ///|
 /// Sums the elements of a lazy list with an initial value.
-pub fn sum[X : Add](l : LazyList[X], init~ : X) -> X {
+pub fn[X : Add] sum(l : LazyList[X], init~ : X) -> X {
   l.fold_left(Add::op_add, init~)
 }
 
 ///|
 /// Zips two lazy lists with a combining function.
-pub fn zip_with[A, B, C](
+pub fn[A, B, C] zip_with(
   self : LazyList[A],
   ys : LazyList[B],
-  f : (A, B) -> C
+  f : (A, B) -> C,
 ) -> LazyList[C] {
   match (self, ys) {
     (Cons(x, xs), Cons(y, ys)) =>
@@ -251,7 +251,7 @@ pub fn zip_with[A, B, C](
 
 ///|
 /// Takes elements from a lazy list while they satisfy a predicate.
-pub fn take_while[T](self : LazyList[T], p : (T) -> Bool) -> LazyList[T] {
+pub fn[T] take_while(self : LazyList[T], p : (T) -> Bool) -> LazyList[T] {
   match self {
     Nil => Nil
     Cons(x, xs) =>
@@ -265,7 +265,7 @@ pub fn take_while[T](self : LazyList[T], p : (T) -> Bool) -> LazyList[T] {
 
 ///|
 /// Takes the first n elements from a lazy list.
-pub fn take[T](self : LazyList[T], n : Int) -> LazyList[T] {
+pub fn[T] take(self : LazyList[T], n : Int) -> LazyList[T] {
   if n <= 0 {
     Nil
   } else {
@@ -278,7 +278,7 @@ pub fn take[T](self : LazyList[T], n : Int) -> LazyList[T] {
 
 ///|
 /// Drops the first n elements from a lazy list.
-pub fn drop[T](self : LazyList[T], n : Int) -> LazyList[T] {
+pub fn[T] drop(self : LazyList[T], n : Int) -> LazyList[T] {
   if n <= 0 {
     self
   } else {
@@ -291,7 +291,7 @@ pub fn drop[T](self : LazyList[T], n : Int) -> LazyList[T] {
 
 ///|
 /// Drops elements from a lazy list while they satisfy a predicate.
-pub fn drop_while[T](self : LazyList[T], p : (T) -> Bool) -> LazyList[T] {
+pub fn[T] drop_while(self : LazyList[T], p : (T) -> Bool) -> LazyList[T] {
   match self {
     Nil => Nil
     Cons(x, xs) => if p(x) { drop_while(xs.force(), p) } else { self }
@@ -300,7 +300,7 @@ pub fn drop_while[T](self : LazyList[T], p : (T) -> Bool) -> LazyList[T] {
 
 ///|
 /// Creates an infinite lazy list with arithmetic progression.
-pub fn infinite_stream[X : Add](start : X, step : X) -> LazyList[X] {
+pub fn[X : Add] infinite_stream(start : X, step : X) -> LazyList[X] {
   Cons(start, Lazy::from_thunk(fn() { infinite_stream(start + step, step) }))
 }
 
@@ -312,10 +312,10 @@ pub fn nats() -> LazyList[Int] {
 
 ///|
 /// Zips a lazy list with a normal list using a combining function.
-pub fn zip_lazy_normal[A, B, C](
+pub fn[A, B, C] zip_lazy_normal(
   self : LazyList[A],
   f : (A, B) -> C,
-  ys : @immut/list.T[B]
+  ys : @immut/list.T[B],
 ) -> @immut/list.T[C] {
   match (self, ys) {
     (Cons(x, xs), Cons(y, ys)) =>
@@ -326,10 +326,10 @@ pub fn zip_lazy_normal[A, B, C](
 
 ///|
 /// Zips two lazy lists with a combining function, concatenating remaining elements.
-pub fn zip_plus[T](
+pub fn[T] zip_plus(
   f : (T, T) -> T,
   ls1 : LazyList[T],
-  ls2 : LazyList[T]
+  ls2 : LazyList[T],
 ) -> LazyList[T] {
   match (ls1, ls2) {
     (Cons(x, xs), Cons(y, ys)) =>
@@ -343,9 +343,9 @@ pub fn zip_plus[T](
 
 ///|
 /// Unfolds a lazy list using a generator function.
-pub fn unfold[T](
+pub fn[T] unfold(
   self : LazyList[T],
-  f : (LazyList[T]) -> (T, LazyList[T])?
+  f : (LazyList[T]) -> (T, LazyList[T])?,
 ) -> LazyList[T] {
   match f(self) {
     None => Nil
@@ -355,7 +355,7 @@ pub fn unfold[T](
 
 ///|
 /// Filters a lazy list using a predicate.
-pub fn filter[T](self : LazyList[T], pred : (T) -> Bool) -> LazyList[T] {
+pub fn[T] filter(self : LazyList[T], pred : (T) -> Bool) -> LazyList[T] {
   match self {
     Nil => Nil
     Cons(x, xs) => {
@@ -371,7 +371,7 @@ pub fn filter[T](self : LazyList[T], pred : (T) -> Bool) -> LazyList[T] {
 
 ///|
 /// Unzips a lazy list of pairs into a pair of lazy lists.
-pub fn unzip[T, W](self : LazyList[(T, W)]) -> (LazyList[T], LazyList[W]) {
+pub fn[T, W] unzip(self : LazyList[(T, W)]) -> (LazyList[T], LazyList[W]) {
   match self {
     Nil => (Nil, Nil)
     Cons((x, y), xs) => {
@@ -383,7 +383,7 @@ pub fn unzip[T, W](self : LazyList[(T, W)]) -> (LazyList[T], LazyList[W]) {
 
 ///|
 /// Converts a lazy list to an array.
-pub fn to_array[T](self : LazyList[T]) -> Array[T] {
+pub fn[T] to_array(self : LazyList[T]) -> Array[T] {
   let res = []
   loop self {
     Nil => ()

--- a/src/lazy_list.mbt
+++ b/src/lazy_list.mbt
@@ -4,7 +4,7 @@
 typealias @lazy.Lazy
 
 ///|
-typealias @immut/list.T as List
+typealias @list.List
 
 ///|
 /// A lazy list type that can be either empty (Nil) or a head element with a lazily
@@ -16,25 +16,26 @@ pub(all) enum LazyList[T] {
 
 ///|
 /// Creates a default empty lazy list for types that implement Default.
-pub fn[X : Default] default() -> LazyList[X] {
+pub fn[X] default() -> LazyList[X] {
   Nil
 }
 
 ///|
 /// Converts an immutable List to a LazyList.
 pub fn[T] LazyList::from_list(ls : List[T]) -> LazyList[T] {
-  loop ls, Nil {
-    Nil, acc => acc
-    Cons(x, xs), acc => continue xs, Cons(x, Lazy::from_value(acc))
+  loop (ls, Nil) {
+    (List::Empty, acc) => acc
+    (List::More(x, tail~), acc) =>
+      continue (tail, Cons(x, Lazy::from_value(acc)))
   }
 }
 
 ///|
 /// Converts an Array to a LazyList in reverse order.
 pub fn[T] LazyList::from_array(ar : Array[T]) -> LazyList[T] {
-  loop ar.length() - 1, Nil {
-    -1, acc => acc
-    n, acc => continue n - 1, Cons(ar[n], Lazy::from_value(acc))
+  loop (ar.length() - 1, Nil) {
+    (-1, acc) => acc
+    (n, acc) => continue (n - 1, Cons(ar[n], Lazy::from_value(acc)))
   }
 }
 
@@ -49,11 +50,12 @@ pub impl[T : Show] Show for LazyList[T] with output(self, logger) {
 ///|
 /// Provides Eq implementation for LazyList, enabling equality comparison.
 pub impl[T : Eq] Eq for LazyList[T] with op_equal(self, other) {
-  loop self, other, true {
-    _, _, false => false
-    Nil, Nil, true => true
-    Cons(x, xs), Cons(y, ys), true => continue xs.force(), ys.force(), x == y
-    _, _, _ => false
+  loop (self, other, true) {
+    (_, _, false) => false
+    (Nil, Nil, true) => true
+    (Cons(x, xs), Cons(y, ys), true) =>
+      continue (xs.force(), ys.force(), x == y)
+    (_, _, _) => false
   }
 }
 
@@ -89,7 +91,7 @@ pub fn[T] concat(self : LazyList[T], other : LazyList[T]) -> LazyList[T] {
   match self {
     Nil => other
     Cons(x, xs) =>
-      Cons(x, @lazy.Lazy::from_thunk(fn() { concat(xs.force(), other) }))
+      Cons(x, @lazy.Lazy::from_thunk(fn() { xs.force().concat(other) }))
   }
 }
 
@@ -111,7 +113,7 @@ pub fn[T, U] map(self : LazyList[T], f : (T) -> U) -> LazyList[U] {
   match self {
     Nil => Nil
     Cons(x, xs) =>
-      Cons(f(x), @lazy.Lazy::from_thunk(fn() { map(xs.force(), f) }))
+      Cons(f(x), @lazy.Lazy::from_thunk(fn() { xs.force().map(f) }))
   }
 }
 
@@ -123,7 +125,7 @@ pub fn[T, U] flat_map(
 ) -> LazyList[U] {
   match self {
     Nil => Nil
-    Cons(x, xs) => f(x).concat(flat_map(xs.force(), f))
+    Cons(x, xs) => f(x).concat(xs.force().flat_map(f))
   }
 }
 
@@ -132,7 +134,7 @@ pub fn[T, U] flat_map(
 pub fn[T] flatten(self : LazyList[LazyList[T]]) -> LazyList[T] {
   match self {
     Nil => Nil
-    Cons(h, t) => h.concat(flatten(t.force()))
+    Cons(h, t) => h.concat(t.force().flatten())
   }
 }
 
@@ -162,7 +164,7 @@ pub fn[T] split_at(self : LazyList[T], i : Int) -> (LazyList[T], LazyList[T]) {
 pub fn[T, U] fold_left(self : LazyList[T], f : (U, T) -> U, init~ : U) -> U {
   match self {
     Nil => init
-    Cons(x, xs) => fold_left(xs.force(), f, init=f(init, x))
+    Cons(x, xs) => xs.force().fold_left(f, init=f(init, x))
   }
 }
 
@@ -196,9 +198,9 @@ pub fn[T] tail(self : LazyList[T]) -> LazyList[T] {
 ///|
 /// Computes the length of a lazy list.
 pub fn[T] length(self : LazyList[T]) -> Int {
-  loop self, 0 {
-    Nil, l => l
-    Cons(_, xs), l => continue xs.force(), l + 1
+  loop (self, 0) {
+    (Nil, l) => l
+    (Cons(_, xs), l) => continue (xs.force(), l + 1)
   }
 }
 
@@ -217,11 +219,11 @@ pub fn[T] each(self : LazyList[T], f : (T) -> Unit) -> Unit {
 ///|
 /// Applies a function to each element with its index for side effects.
 pub fn[T] eachi(self : LazyList[T], f : (Int, T) -> Unit) -> Unit {
-  loop self, 0 {
-    Nil, _ => ()
-    Cons(x, xs), i => {
+  loop (self, 0) {
+    (Nil, _) => ()
+    (Cons(x, xs), i) => {
       f(i, x)
-      continue xs.force(), i + 1
+      continue (xs.force(), i + 1)
     }
   }
 }
@@ -243,7 +245,7 @@ pub fn[A, B, C] zip_with(
     (Cons(x, xs), Cons(y, ys)) =>
       Cons(
         f(x, y),
-        Lazy::from_thunk(fn() { zip_with(xs.force(), ys.force(), f) }),
+        Lazy::from_thunk(fn() { xs.force().zip_with(ys.force(), f) }),
       )
     (_, _) => Nil
   }
@@ -256,7 +258,7 @@ pub fn[T] take_while(self : LazyList[T], p : (T) -> Bool) -> LazyList[T] {
     Nil => Nil
     Cons(x, xs) =>
       if p(x) {
-        Cons(x, Lazy::from_thunk(fn() { take_while(xs.force(), p) }))
+        Cons(x, Lazy::from_thunk(fn() { xs.force().take_while(p) }))
       } else {
         Nil
       }
@@ -271,7 +273,7 @@ pub fn[T] take(self : LazyList[T], n : Int) -> LazyList[T] {
   } else {
     match self {
       Nil => Nil
-      Cons(x, xs) => Cons(x, Lazy::from_value(take(xs.force(), n - 1)))
+      Cons(x, xs) => Cons(x, Lazy::from_value(xs.force().take(n - 1)))
     }
   }
 }
@@ -284,7 +286,7 @@ pub fn[T] drop(self : LazyList[T], n : Int) -> LazyList[T] {
   } else {
     match self {
       Nil => Nil
-      Cons(_, xs) => drop(xs.force(), n - 1)
+      Cons(_, xs) => xs.force().drop(n - 1)
     }
   }
 }
@@ -294,7 +296,7 @@ pub fn[T] drop(self : LazyList[T], n : Int) -> LazyList[T] {
 pub fn[T] drop_while(self : LazyList[T], p : (T) -> Bool) -> LazyList[T] {
   match self {
     Nil => Nil
-    Cons(x, xs) => if p(x) { drop_while(xs.force(), p) } else { self }
+    Cons(x, xs) => if p(x) { xs.force().drop_while(p) } else { self }
   }
 }
 
@@ -315,12 +317,12 @@ pub fn nats() -> LazyList[Int] {
 pub fn[A, B, C] zip_lazy_normal(
   self : LazyList[A],
   f : (A, B) -> C,
-  ys : @immut/list.T[B],
-) -> @immut/list.T[C] {
+  ys : @list.List[B],
+) -> @list.List[C] {
   match (self, ys) {
-    (Cons(x, xs), Cons(y, ys)) =>
-      Cons(f(x, y), zip_lazy_normal(xs.force(), f, ys))
-    (_, _) => Nil
+    (Cons(x, xs), List::More(y, tail~)) =>
+      @list.construct(f(x, y), xs.force().zip_lazy_normal(f, tail))
+    (_, _) => @list.empty()
   }
 }
 
@@ -361,9 +363,9 @@ pub fn[T] filter(self : LazyList[T], pred : (T) -> Bool) -> LazyList[T] {
     Cons(x, xs) => {
       let xs = xs.force()
       if pred(x) {
-        Cons(x, Lazy::from_thunk(fn() { filter(xs, pred) }))
+        Cons(x, Lazy::from_thunk(fn() { xs.filter(pred) }))
       } else {
-        filter(xs, pred)
+        xs.filter(pred)
       }
     }
   }

--- a/src/ll_wbtest.mbt
+++ b/src/ll_wbtest.mbt
@@ -2,134 +2,134 @@
 test "lazy list" {
   let l1 = LazyList::from_array([1, 2, 3, 4, 5, 6])
   let l2 = LazyList::from_array([7, 8, 9, 10, 11])
-  inspect!(l1, content="[1, 2, 3, 4, 5, 6]")
-  inspect!(l2, content="[7, 8, 9, 10, 11]")
-  assert_true!(l1 == l1)
-  inspect!(l1.zip_with(l2, Add::op_add), content="[8, 10, 12, 14, 16]")
-  inspect!(l1.index(3), content="4")
+  inspect(l1, content="[1, 2, 3, 4, 5, 6]")
+  inspect(l2, content="[7, 8, 9, 10, 11]")
+  assert_true(l1 == l1)
+  inspect(l1.zip_with(l2, Add::op_add), content="[8, 10, 12, 14, 16]")
+  inspect(l1.index(3), content="4")
 }
 
 ///|
 test "lazy" {
   let x = nats()
-  inspect!(x.take(10), content="[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]")
+  inspect(x.take(10), content="[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]")
   let y = nats().map(fn(x) { x + 10 })
-  inspect!(
+  inspect(
     y.take(20),
     content="[10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]",
   )
   let z = x.zip_with(y, Add::op_add)
-  inspect!(z.take(10), content="[10, 12, 14, 16, 18, 20, 22, 24, 26, 28]")
-  inspect!(
+  inspect(z.take(10), content="[10, 12, 14, 16, 18, 20, 22, 24, 26, 28]")
+  inspect(
     z.drop(10).take(10),
     content="[30, 32, 34, 36, 38, 40, 42, 44, 46, 48]",
   )
-  inspect!(z.head(), content="10")
-  inspect!(z.tail().take(5), content="[12, 14, 16, 18, 20]")
+  inspect(z.head(), content="10")
+  inspect(z.tail().take(5), content="[12, 14, 16, 18, 20]")
 }
 
 ///|
 test "empty list operations" {
   let empty = Nil
-  assert_true!(empty == LazyList::from_array([]))
-  assert_eq!(empty.length(), 0)
-  assert_eq!(empty.to_array(), [])
-  inspect!(empty, content="[]")
+  assert_true(empty == LazyList::from_array([]))
+  assert_eq(empty.length(), 0)
+  assert_eq(empty.to_array(), [])
+  inspect(empty, content="[]")
 }
 
 ///|
 test "default construction" {
   let empty = default()
-  assert_true!(empty == Nil)
-  assert_eq!(empty.length(), 0)
+  assert_true(empty == Nil)
+  assert_eq(empty.length(), 0)
 }
 
 ///|
 test "infinite operations" {
   let ones = repeat(1)
-  inspect!(ones.take(5), content="[1, 1, 1, 1, 1]")
-  assert_eq!(ones.take(10).length(), 10)
-  assert_eq!(ones.take(0), Nil)
+  inspect(ones.take(5), content="[1, 1, 1, 1, 1]")
+  assert_eq(ones.take(10).length(), 10)
+  assert_eq(ones.take(0), Nil)
 }
 
 ///|
 test "tails function" {
   let lst = LazyList::from_array([1, 2, 3])
   let t = lst.tails()
-  inspect!(t.index(0), content="[1, 2, 3]")
-  inspect!(t.index(1), content="[2, 3]")
-  inspect!(t.index(2), content="[3]")
-  inspect!(t.index(3), content="[]")
+  inspect(t.index(0), content="[1, 2, 3]")
+  inspect(t.index(1), content="[2, 3]")
+  inspect(t.index(2), content="[3]")
+  inspect(t.index(3), content="[]")
 }
 
 ///|
 test "edge cases for indexing" {
   let lst = LazyList::from_array([10, 20, 30])
-  assert_eq!(lst.index(0), 10)
-  assert_eq!(lst.index(2), 30)
+  assert_eq(lst.index(0), 10)
+  assert_eq(lst.index(2), 30)
 }
 
 ///|
 test "filter operations" {
   let nums = nats().take(10)
   let evens = nums.filter(fn(x) { x % 2 == 0 })
-  inspect!(evens, content="[0, 2, 4, 6, 8]")
+  inspect(evens, content="[0, 2, 4, 6, 8]")
   let empty_filter = nums.filter(fn(_) { false })
-  assert_true!(empty_filter == Nil)
+  assert_true(empty_filter == Nil)
 }
 
 ///|
 test "split_at edge cases" {
   let lst = LazyList::from_array([1, 2, 3, 4])
   let (a, b) = lst.split_at(0)
-  assert_true!(a == Nil)
-  assert_true!(b == lst)
+  assert_true(a == Nil)
+  assert_true(b == lst)
   let (c, d) = lst.split_at(5)
-  assert_eq!(c.length(), 4)
-  assert_true!(d == Nil)
+  assert_eq(c.length(), 4)
+  assert_true(d == Nil)
 }
 
 ///|
 test "fold operations" {
   let lst = LazyList::from_array([1, 2, 3])
-  assert_eq!(lst.fold_left(Add::op_add, init=0), 6)
-  assert_eq!(lst.fold_left(Mul::op_mul, init=1), 6)
-  assert_eq!(lst.fold_right(Add::op_add, init=0), 6)
+  assert_eq(lst.fold_left(Add::op_add, init=0), 6)
+  assert_eq(lst.fold_left(Mul::op_mul, init=1), 6)
+  assert_eq(lst.fold_right(Add::op_add, init=0), 6)
 }
 
 ///|
 test "unzip operation" {
   let pairs = LazyList::from_array([(1, "a"), (2, "b"), (3, "c")])
   let (nums, chars) = pairs.unzip()
-  inspect!(nums, content="[1, 2, 3]")
-  inspect!(chars, content="[a, b, c]")
+  inspect(nums, content="[1, 2, 3]")
+  inspect(chars, content="[a, b, c]")
 }
 
 ///|
 test "flat_map operations" {
   let lst = LazyList::from_array([1, 2, 3])
   let expanded = lst.flat_map(fn(x) { LazyList::from_array([x, x * 10]) })
-  inspect!(expanded, content="[1, 10, 2, 20, 3, 30]")
+  inspect(expanded, content="[1, 10, 2, 20, 3, 30]")
   let empty_flat = lst.flat_map(fn(_) { Nil })
-  assert_true!(empty_flat == Nil)
+  assert_true(empty_flat == Nil)
 }
 
 ///|
 test "drop operations" {
   let lst = LazyList::from_array([1, 2, 3, 4, 5])
-  assert_true!(lst.drop(0) == lst)
-  assert_true!(lst.drop(5) == Nil)
-  inspect!(lst.drop(2), content="[3, 4, 5]")
-  inspect!(lst.drop_while(fn(x) { x < 3 }), content="[3, 4, 5]")
+  assert_true(lst.drop(0) == lst)
+  assert_true(lst.drop(5) == Nil)
+  inspect(lst.drop(2), content="[3, 4, 5]")
+  inspect(lst.drop_while(fn(x) { x < 3 }), content="[3, 4, 5]")
 }
 
 ///|
 test "take_while edge cases" {
   let lst = LazyList::from_array([2, 4, 6, 7, 8])
   let taken = lst.take_while(fn(x) { x % 2 == 0 })
-  inspect!(taken, content="[2, 4, 6]")
+  inspect(taken, content="[2, 4, 6]")
   let none_taken = lst.take_while(fn(_) { false })
-  assert_true!(none_taken == Nil)
+  assert_true(none_taken == Nil)
 }
 
 ///|
@@ -137,9 +137,9 @@ test "zip_with different lengths" {
   let short = LazyList::from_array([1, 2])
   let long = LazyList::from_array([10, 20, 30])
   let zipped1 = short.zip_with(long, Add::op_add)
-  inspect!(zipped1, content="[11, 22]")
+  inspect(zipped1, content="[11, 22]")
   let zipped2 = long.zip_with(short, Add::op_add)
-  inspect!(zipped2, content="[11, 22]")
+  inspect(zipped2, content="[11, 22]")
 }
 
 ///|
@@ -150,25 +150,25 @@ test "flatten operation" {
     LazyList::from_array([4, 5]),
   ])
   let flat = lists.flatten()
-  inspect!(flat, content="[1, 2, 3, 4, 5]")
+  inspect(flat, content="[1, 2, 3, 4, 5]")
 }
 
 ///|
 test "infinite stream generation" {
   let tens = infinite_stream(0, 10)
-  inspect!(tens.take(5), content="[0, 10, 20, 30, 40]")
+  inspect(tens.take(5), content="[0, 10, 20, 30, 40]")
   let decimals = infinite_stream(0.1, 0.1)
-  inspect!(
+  inspect(
     decimals.take(3).to_array().map(fn(x) { x.to_string() }),
-    content=
+    content=(
       #|["0.1", "0.2", "0.30000000000000004"]
-    ,
+    ),
   )
 }
 
 ///|
 test "head and tail edge cases" {
   let single = LazyList::from_array([42])
-  assert_eq!(single.head(), 42)
-  assert_true!(single.tail() == Nil)
+  assert_eq(single.head(), 42)
+  assert_true(single.tail() == Nil)
 }

--- a/src/ll_wbtest.mbt
+++ b/src/ll_wbtest.mbt
@@ -30,7 +30,7 @@ test "lazy" {
 
 ///|
 test "empty list operations" {
-  let empty = Nil
+  let empty : LazyList[Unit] = Nil
   assert_true(empty == LazyList::from_array([]))
   assert_eq(empty.length(), 0)
   assert_eq(empty.to_array(), [])
@@ -39,7 +39,7 @@ test "empty list operations" {
 
 ///|
 test "default construction" {
-  let empty = default()
+  let empty : LazyList[Unit] = default()
   assert_true(empty == Nil)
   assert_eq(empty.length(), 0)
 }
@@ -110,7 +110,9 @@ test "flat_map operations" {
   let lst = LazyList::from_array([1, 2, 3])
   let expanded = lst.flat_map(fn(x) { LazyList::from_array([x, x * 10]) })
   inspect(expanded, content="[1, 10, 2, 20, 3, 30]")
-  let empty_flat = lst.flat_map(fn(_) { Nil })
+  let empty_flat : LazyList[Int] = lst.flat_map(fn(_) {
+    LazyList::from_array([])
+  })
   assert_true(empty_flat == Nil)
 }
 


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

- Replace deprecated @immut/list.T with @list.List type alias
- Remove unused Default trait bound from default() function  
- Update deprecated loop syntax from 'loop a, b' to 'loop (a, b)'
- Fix deprecated function call syntax to use proper method calls
- Update @list constructors to use correct Empty/More patterns and construction functions
- Add type annotation to resolve unresolved type variable warning in tests

All compiler warnings have been resolved while maintaining original functionality.